### PR TITLE
feat: Add a setup function to generate required sheets

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -1,0 +1,76 @@
+/**
+ * @file Configuracion.gs
+ * @description Contiene las funciones para configurar la hoja de cálculo,
+ * como la creación de las hojas necesarias.
+ */
+
+/**
+ * Función principal para configurar o verificar la estructura de la hoja de cálculo.
+ * Crea las hojas necesarias con sus encabezados si no existen.
+ */
+function configurarHojas() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const ui = SpreadsheetApp.getUi();
+
+  const hojas = [
+    {
+      nombre: SHEET_ORDERS,
+      headers: ['Fecha', 'Cliente', 'Producto (NP)', 'Cantidad', 'Unidad Venta (UMV)', 'Precio', 'Estado']
+    },
+    {
+      nombre: SHEET_SKU,
+      headers: [
+        'Nombre Producto (NP)', 'Producto Base (PB)', 'Cantidad Venta', 'Unidad Venta (UMV)',
+        'Formato Adq.', 'Cantidad Adq.', 'Unidad Adq. (UMA)', 'Categoría', 'Proveedor',
+        'Teléfono Prov.', 'UMPB', 'Merma%', 'Stock de Seguridad'
+      ]
+    },
+    {
+      nombre: SHEET_STOCK,
+      headers: ['Producto Base (PB)', 'Stock Actual', 'Unidad (UMPB)', 'Fecha Snapshot']
+    },
+    {
+      nombre: SHEET_ENVASADO,
+      headers: ['Producto (NP)', 'Cantidad a Envasar', 'Unidad (UMV)']
+    },
+    {
+      nombre: SHEET_ADQUISICION,
+      headers: ['Producto Base (PB)', 'Demanda Neta', 'Lote de Compra', '# Lotes a Comprar', 'Total a Comprar', 'Unidad (UMPB)']
+    }
+  ];
+
+  let hojasCreadas = [];
+  let hojasExistentes = [];
+
+  hojas.forEach(hojaInfo => {
+    let hoja = ss.getSheetByName(hojaInfo.nombre);
+    if (!hoja) {
+      hoja = ss.insertSheet(hojaInfo.nombre);
+      hojasCreadas.push(hojaInfo.nombre);
+
+      const headerRange = hoja.getRange(1, 1, 1, hojaInfo.headers.length);
+      headerRange.setValues([hojaInfo.headers]);
+      headerRange.setFontWeight('bold');
+      headerRange.setBackground('#DDEBF7');
+      hoja.setFrozenRows(1);
+
+      // Autoajustar columnas para mejor visualización
+      for (let i = 1; i <= hojaInfo.headers.length; i++) {
+        hoja.autoResizeColumn(i);
+      }
+    } else {
+      hojasExistentes.push(hojaInfo.nombre);
+    }
+  });
+
+  // Informar al usuario sobre el resultado
+  let mensaje = '';
+  if (hojasCreadas.length > 0) {
+    mensaje += 'Hojas creadas: ' + hojasCreadas.join(', ') + '.\n\n';
+  }
+  if (hojasExistentes.length > 0) {
+    mensaje += 'Hojas ya existentes: ' + hojasExistentes.join(', ') + '.';
+  }
+
+  ui.alert('Configuración completada', mensaje, ui.ButtonSet.OK);
+}

--- a/Menu.gs
+++ b/Menu.gs
@@ -4,6 +4,8 @@
 function crearMenu() {
   const ui = SpreadsheetApp.getUi();
   ui.createMenu('SantiagoNatural')
+      .addItem('Configurar/Verificar Hojas', 'configurarHojas')
+      .addSeparator()
       .addItem('Iniciar día', 'iniciarDiaOperativo')
       .addSeparator()
       .addItem('Generar Listas', 'calcularTodo')


### PR DESCRIPTION
This change introduces a new feature to the Google Apps Script project that allows users to automatically create all the necessary sheets (`Orders`, `SKU`, `Stock`, `Envasado`, `Adquisicion`) required for the script to function correctly.

A new file, `Configuracion.gs`, has been added to house the setup logic. The `configurarHojas()` function in this file checks for the existence of the required sheets and creates them with the appropriate headers if they are missing.

The main menu has been updated with a new "Configuracion/Verificar Hojas" item, which triggers this setup function. This makes the project much easier to set up for new users, as they no longer need to create the sheets manually.