### PR TITLE
Feat: Automate Sheet Creation on Open

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -10,6 +10,7 @@
  * Muestra la barra lateral y crea el menú personalizado.
  */
 function onOpen() {
+  configurarHojas();
   showSidebar();
   crearMenu();
 }


### PR DESCRIPTION
This commit introduces a mechanism to automatically verify and create required sheets every time the spreadsheet is opened.

The `configurarHojas()` function, which handles the creation of missing operational and historical sheets, is now called from the `onOpen()` trigger. This ensures the spreadsheet's integrity and prevents errors from missing sheets.

This change also addresses the user's query regarding the sheets "Inventario (histórico)" and "_IMPR_INV". The former is confirmed as a required system sheet, while the latter is identified as obsolete and is not included in the automated setup.