### PR TITLE
Move `configurarHojas()` out of `onOpen()` to prevent timeouts.

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -10,7 +10,6 @@
  * Muestra la barra lateral y crea el menú personalizado.
  */
 function onOpen() {
-  configurarHojas();
   showSidebar();
   crearMenu();
 }

--- a/Menu.gs
+++ b/Menu.gs
@@ -7,5 +7,7 @@ function crearMenu() {
   SpreadsheetApp.getUi()
       .createMenu('Panel de Operaciones')
       .addItem('Mostrar Panel', 'showSidebar')
+      .addSeparator()
+      .addItem('🛠️ Configurar Hojas', 'configurarHojas')
       .addToUi();
 }


### PR DESCRIPTION
The slow `configurarHojas()` function was causing the `onOpen()` trigger to exceed its 30-second execution limit, which prevented the custom menu from appearing.

This change moves the call to `configurarHojas()` into a separate menu item, "🛠️ Configurar Hojas", allowing the user to run the setup manually. The `onOpen()` function is now only responsible for showing the sidebar and creating the menu, ensuring it runs quickly and reliably.