### PR TITLE
Refactor global constants to use a single namespace object.

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -39,11 +39,11 @@ function configurarHojas() {
  */
 function configurarHojasOperacion(ss) {
   const hojas = [
-    { nombre: SHEET_ORDERS, headers: ['Fecha', 'Cliente', 'Producto (NP)', 'Cantidad', 'Unidad Venta (UMV)', 'Precio', 'Estado'] },
-    { nombre: SHEET_SKU, headers: ['Nombre Producto (NP)', 'Producto Base (PB)', 'Cantidad Venta', 'Unidad Venta (UMV)', 'Formato Adq.', 'Cantidad Adq.', 'Unidad Adq. (UMA)', 'Categoría', 'Proveedor', 'Teléfono Prov.', 'UMPB', 'Merma%', 'Stock de Seguridad'] },
-    { nombre: SHEET_STOCK, headers: ['Producto Base (PB)', 'Stock Actual', 'Unidad (UMPB)', 'Fecha Snapshot'] },
-    { nombre: SHEET_ENVASADO, headers: ['Producto (NP)', 'Cantidad a Envasar', 'Unidad (UMV)'] },
-    { nombre: SHEET_ADQUISICION, headers: ['Producto Base (PB)', 'Demanda Neta', 'Lote de Compra', '# Lotes a Comprar', 'Total a Comprar', 'Unidad (UMPB)'] }
+    { nombre: C.SHEET_ORDERS, headers: ['Fecha', 'Cliente', 'Producto (NP)', 'Cantidad', 'Unidad Venta (UMV)', 'Precio', 'Estado'] },
+    { nombre: C.SHEET_SKU, headers: ['Nombre Producto (NP)', 'Producto Base (PB)', 'Cantidad Venta', 'Unidad Venta (UMV)', 'Formato Adq.', 'Cantidad Adq.', 'Unidad Adq. (UMA)', 'Categoría', 'Proveedor', 'Teléfono Prov.', 'UMPB', 'Merma%', 'Stock de Seguridad'] },
+    { nombre: C.SHEET_STOCK, headers: ['Producto Base (PB)', 'Stock Actual', 'Unidad (UMPB)', 'Fecha Snapshot'] },
+    { nombre: C.SHEET_ENVASADO, headers: ['Producto (NP)', 'Cantidad a Envasar', 'Unidad (UMV)'] },
+    { nombre: C.SHEET_ADQUISICION, headers: ['Producto Base (PB)', 'Demanda Neta', 'Lote de Compra', '# Lotes a Comprar', 'Total a Comprar', 'Unidad (UMPB)'] }
   ];
 
   let creadas = [];
@@ -76,8 +76,8 @@ function configurarHojasOperacion(ss) {
  */
 function configurarHojasHistorial(ss) {
   const hojas = [
-    { nombre: SHEET_ADQUISICIONES_HISTORIAL, formula: FORMULA_ADQUISICIONES },
-    { nombre: SHEET_INVENTARIO_HISTORICO, formula: FORMULA_INVENTARIO }
+    { nombre: C.SHEET_ADQUISICIONES_HISTORIAL, formula: C.FORMULA_ADQUISICIONES },
+    { nombre: C.SHEET_INVENTARIO_HISTORICO, formula: C.FORMULA_INVENTARIO }
   ];
 
   let creadas = [];

--- a/Constantes.gs
+++ b/Constantes.gs
@@ -4,16 +4,18 @@
  * centralizar la configuración.
  */
 
-// --- NOMBRES DE HOJAS DE OPERACIÓN ---
-const SHEET_ORDERS = "Orders";
-const SHEET_SKU = "SKU";
-const SHEET_ENVASADO = "Envasado";
-const SHEET_ADQUISICION = "Adquisicion";
-const SHEET_STOCK = "Stock";
+const C = Object.freeze({
+  // --- NOMBRES DE HOJAS DE OPERACIÓN ---
+  SHEET_ORDERS: "Orders",
+  SHEET_SKU: "SKU",
+  SHEET_ENVASADO: "Envasado",
+  SHEET_ADQUISICION: "Adquisicion",
+  SHEET_STOCK: "Stock",
 
-// --- NOMBRES Y FÓRMULAS DE HOJAS DE HISTORIAL ---
-const SHEET_ADQUISICIONES_HISTORIAL = "Adquisiciones (historial)";
-const SHEET_INVENTARIO_HISTORICO = "Inventario (histórico)";
+  // --- NOMBRES Y FÓRMULAS DE HOJAS DE HISTORIAL ---
+  SHEET_ADQUISICIONES_HISTORIAL: "Adquisiciones (historial)",
+  SHEET_INVENTARIO_HISTORICO: "Inventario (histórico)",
 
-const FORMULA_ADQUISICIONES = '=IMPORTRANGE("https://docs.google.com/spreadsheets/d/1vCZejbBPMh73nbAhdZNYFOlvJvRoMA7PVSCUiLl8MMQ","HISTORIAL_Adquisiciones!A:Z")';
-const FORMULA_INVENTARIO = '=IMPORTRANGE("https://docs.google.com/spreadsheets/d/1G2VsuIfuaOWEmsPmJacmPuyFFUwq5WMKyE9p5Vrxysk","Inventario Histórico!A:Z")';
+  FORMULA_ADQUISICIONES: '=IMPORTRANGE("https://docs.google.com/spreadsheets/d/1vCZejbBPMh73nbAhdZNYFOlvJvRoMA7PVSCUiLl8MMQ","HISTORIAL_Adquisiciones!A:Z")',
+  FORMULA_INVENTARIO: '=IMPORTRANGE("https://docs.google.com/spreadsheets/d/1G2VsuIfuaOWEmsPmJacmPuyFFUwq5WMKyE9p5Vrxysk","Inventario Histórico!A:Z")'
+});

--- a/Limpieza.gs
+++ b/Limpieza.gs
@@ -10,7 +10,7 @@
  */
 function limpiarHojasOperativas() {
   const ui = SpreadsheetApp.getUi();
-  const hojasALimpiar = [SHEET_ORDERS, SHEET_ENVASADO, SHEET_ADQUISICION];
+  const hojasALimpiar = [C.SHEET_ORDERS, C.SHEET_ENVASADO, C.SHEET_ADQUISICION];
 
   let hojasLimpiadas = [];
   let hojasNoEncontradas = [];

--- a/LogicaNegocio.gs
+++ b/LogicaNegocio.gs
@@ -41,10 +41,10 @@ function calcularTodo() {
  */
 function escribirHojaAdquisicion(adquisicion) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
-  let sheet = ss.getSheetByName(SHEET_ADQUISICION);
+  let sheet = ss.getSheetByName(C.SHEET_ADQUISICION);
 
   if (!sheet) {
-    sheet = ss.insertSheet(SHEET_ADQUISICION);
+    sheet = ss.insertSheet(C.SHEET_ADQUISICION);
   }
 
   sheet.clear();
@@ -180,10 +180,10 @@ function calcularDemandaPB(demandaEnvasado, skuMap) {
  */
 function calcularDemandaEnvasado() {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const sheet = ss.getSheetByName(SHEET_ORDERS);
+  const sheet = ss.getSheetByName(C.SHEET_ORDERS);
 
   if (!sheet) {
-    SpreadsheetApp.getUi().alert(`La hoja "${SHEET_ORDERS}" no fue encontrada.`);
+    SpreadsheetApp.getUi().alert(`La hoja "${C.SHEET_ORDERS}" no fue encontrada.`);
     return null;
   }
 
@@ -230,10 +230,10 @@ function calcularDemandaEnvasado() {
  */
 function escribirHojaEnvasado(demandaEnvasado) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
-  let sheet = ss.getSheetByName(SHEET_ENVASADO);
+  let sheet = ss.getSheetByName(C.SHEET_ENVASADO);
 
   if (!sheet) {
-    sheet = ss.insertSheet(SHEET_ENVASADO);
+    sheet = ss.insertSheet(C.SHEET_ENVASADO);
   }
 
   // Limpiar hoja


### PR DESCRIPTION
This change resolves a "SyntaxError: Identifier has already been declared" error that occurred because constants were being declared in multiple files in the global scope of the Google Apps Script project.

All global constants have been moved into a single, frozen object `C` in `Constantes.gs`. All other files (`Configuracion.gs`, `Limpieza.gs`, `LogicaNegocio.gs`) have been updated to reference the constants via this new object (e.g., `C.SHEET_ORDERS`).

This approach fixes the immediate bug and makes the code more robust and maintainable by preventing future naming collisions.